### PR TITLE
Fix some more `@idrefs`

### DIFF
--- a/test_hpxmls/real_homes/house51.xml
+++ b/test_hpxmls/real_homes/house51.xml
@@ -645,7 +645,7 @@
     </ConsumptionDetails>
   </Consumption>
   <Consumption>
-    <BuildingID idref='Building1'/>
+    <BuildingID idref='bldg1'/>
     <CustomerID/>
     <ConsumptionDetails>
       <ConsumptionInfo>

--- a/test_hpxmls/real_homes/house52.xml
+++ b/test_hpxmls/real_homes/house52.xml
@@ -665,7 +665,7 @@
     </ConsumptionDetails>
   </Consumption>
   <Consumption>
-    <BuildingID idref='Building1'/>
+    <BuildingID idref='bldg1'/>
     <CustomerID/>
     <ConsumptionDetails>
       <ConsumptionInfo>

--- a/test_hpxmls/real_homes/house53.xml
+++ b/test_hpxmls/real_homes/house53.xml
@@ -714,7 +714,7 @@
     </ConsumptionDetails>
   </Consumption>
   <Consumption>
-    <BuildingID idref='Building1'/>
+    <BuildingID idref='bldg1'/>
     <CustomerID/>
     <ConsumptionDetails>
       <ConsumptionInfo>

--- a/test_hpxmls/real_homes/house54.xml
+++ b/test_hpxmls/real_homes/house54.xml
@@ -610,7 +610,7 @@
     </ConsumptionDetails>
   </Consumption>
   <Consumption>
-    <BuildingID idref='Building1'/>
+    <BuildingID idref='bldg1'/>
     <CustomerID/>
     <ConsumptionDetails>
       <ConsumptionInfo>

--- a/test_hpxmls/real_homes/house57.xml
+++ b/test_hpxmls/real_homes/house57.xml
@@ -640,7 +640,7 @@
     </ConsumptionDetails>
   </Consumption>
   <Consumption>
-    <BuildingID idref='Building1'/>
+    <BuildingID idref='bldg1'/>
     <CustomerID/>
     <ConsumptionDetails>
       <ConsumptionInfo>

--- a/test_hpxmls/real_homes/house60.xml
+++ b/test_hpxmls/real_homes/house60.xml
@@ -605,7 +605,7 @@
     </ConsumptionDetails>
   </Consumption>
   <Consumption>
-    <BuildingID idref='Building1'/>
+    <BuildingID idref='bldg1'/>
     <CustomerID/>
     <ConsumptionDetails>
       <ConsumptionInfo>

--- a/test_hpxmls/real_homes/house61.xml
+++ b/test_hpxmls/real_homes/house61.xml
@@ -616,7 +616,7 @@
     </ConsumptionDetails>
   </Consumption>
   <Consumption>
-    <BuildingID idref='Building1'/>
+    <BuildingID idref='bldg1'/>
     <CustomerID/>
     <ConsumptionDetails>
       <ConsumptionInfo>

--- a/test_hpxmls/real_homes/house62.xml
+++ b/test_hpxmls/real_homes/house62.xml
@@ -704,7 +704,7 @@
     </ConsumptionDetails>
   </Consumption>
   <Consumption>
-    <BuildingID idref='Building1'/>
+    <BuildingID idref='bldg1'/>
     <CustomerID/>
     <ConsumptionDetails>
       <ConsumptionInfo>

--- a/test_hpxmls/real_homes/house63.xml
+++ b/test_hpxmls/real_homes/house63.xml
@@ -657,7 +657,7 @@
     </ConsumptionDetails>
   </Consumption>
   <Consumption>
-    <BuildingID idref='Building1'/>
+    <BuildingID idref='bldg1'/>
     <CustomerID/>
     <ConsumptionDetails>
       <ConsumptionInfo>

--- a/test_hpxmls/real_homes/house64.xml
+++ b/test_hpxmls/real_homes/house64.xml
@@ -752,7 +752,7 @@
     </ConsumptionDetails>
   </Consumption>
   <Consumption>
-    <BuildingID idref='Building1'/>
+    <BuildingID idref='bldg1'/>
     <CustomerID/>
     <ConsumptionDetails>
       <ConsumptionInfo>

--- a/test_hpxmls/real_homes/house65.xml
+++ b/test_hpxmls/real_homes/house65.xml
@@ -676,7 +676,7 @@
     </ConsumptionDetails>
   </Consumption>
   <Consumption>
-    <BuildingID idref='Building1'/>
+    <BuildingID idref='bldg1'/>
     <CustomerID/>
     <ConsumptionDetails>
       <ConsumptionInfo>

--- a/test_hpxmls/real_homes/house66.xml
+++ b/test_hpxmls/real_homes/house66.xml
@@ -700,7 +700,7 @@
     </ConsumptionDetails>
   </Consumption>
   <Consumption>
-    <BuildingID idref='Building1'/>
+    <BuildingID idref='bldg1'/>
     <CustomerID/>
     <ConsumptionDetails>
       <ConsumptionInfo>

--- a/test_hpxmls/real_homes/house67.xml
+++ b/test_hpxmls/real_homes/house67.xml
@@ -710,7 +710,7 @@
     </ConsumptionDetails>
   </Consumption>
   <Consumption>
-    <BuildingID idref='Building1'/>
+    <BuildingID idref='bldg1'/>
     <CustomerID/>
     <ConsumptionDetails>
       <ConsumptionInfo>

--- a/test_hpxmls/real_homes/house68.xml
+++ b/test_hpxmls/real_homes/house68.xml
@@ -653,7 +653,7 @@
     </ConsumptionDetails>
   </Consumption>
   <Consumption>
-    <BuildingID idref='Building1'/>
+    <BuildingID idref='bldg1'/>
     <CustomerID/>
     <ConsumptionDetails>
       <ConsumptionInfo>

--- a/test_hpxmls/real_homes/house69.xml
+++ b/test_hpxmls/real_homes/house69.xml
@@ -729,7 +729,7 @@
     </ConsumptionDetails>
   </Consumption>
   <Consumption>
-    <BuildingID idref='Building1'/>
+    <BuildingID idref='bldg1'/>
     <CustomerID/>
     <ConsumptionDetails>
       <ConsumptionInfo>

--- a/test_hpxmls/real_homes/house70.xml
+++ b/test_hpxmls/real_homes/house70.xml
@@ -647,7 +647,7 @@
     </ConsumptionDetails>
   </Consumption>
   <Consumption>
-    <BuildingID idref='Building1'/>
+    <BuildingID idref='bldg1'/>
     <CustomerID/>
     <ConsumptionDetails>
       <ConsumptionInfo>

--- a/tests/test_weather_normalization.py
+++ b/tests/test_weather_normalization.py
@@ -19,6 +19,7 @@ SKIP_FILENAMES = {
     "house18.xml",
     "house32.xml",
     "house37.xml",
+    "house53.xml",
     "house83.xml",
     "house84.xml",
     "house54.xml",
@@ -82,7 +83,9 @@ def test_weather_retrieval(results_dir, filename):
     "filename", ira_rebate_hpxmls + real_home_hpxmls + ihmh_home_hpxmls, ids=lambda x: x.stem
 )
 def test_curve_fit(results_dir, filename):
-    # Files that do not meet the utility bill criteria are skipped for now. They will be included in the tests again once simplified calibration is added.
+    # Files that do not meet the utility bill criteria are skipped for now.
+    # They will be included in the tests again once simplified calibration is added.
+    # See https://github.com/NREL/OpenStudio-HPXML-Calibration/issues/43
     if filename.name in SKIP_FILENAMES:
         pytest.skip(f"Skipping test for {filename.name}")
 


### PR DESCRIPTION
I found that not all `@idrefs` were fixed in https://github.com/NREL/OpenStudio-HPXML-Calibration/pull/32/commits/c2662f7ca8419ef2d354c0ae9ec1bce015584eb2. Now they are all fixed.