### PR TITLE
Set limits when adjusting DHW efficiencies

### DIFF
--- a/src/measures/ModifyXML/measure.rb
+++ b/src/measures/ModifyXML/measure.rb
@@ -556,15 +556,10 @@ class ModifyXML < OpenStudio::Measure::ModelMeasure
     hpxml_bldg.water_heating_systems.each do |water_heating_system|
       if water_heating_system.energy_factor
         if water_heating_system.water_heater_type == HPXML::WaterHeaterTypeHeatPump
-          new_ef = water_heating_system.energy_factor * multiplier
           # Apply HPXML bounds https://openstudio-hpxml.readthedocs.io/en/latest/workflow_inputs.html#heat-pump
-          if new_ef <= 1.0
-            new_ef = 1.01
-          elsif new_ef > 5.0
-            new_ef = 5.0
-          end
+          new_ef = [[water_heating_system.energy_factor * multiplier, 1.01].max, 5.0].min
         else
-          new_ef = [water_heating_system.energy_factor * multiplier, 0.999].min
+          new_ef = [water_heating_system.energy_factor * multiplier, 0.99].min
         end
         if new_ef != water_heating_system.energy_factor
           water_heating_system.recovery_efficiency = nil
@@ -574,15 +569,10 @@ class ModifyXML < OpenStudio::Measure::ModelMeasure
       end
       if water_heating_system.uniform_energy_factor
         if water_heating_system.water_heater_type == HPXML::WaterHeaterTypeHeatPump
-          new_uef = water_heating_system.uniform_energy_factor * multiplier
           # Apply HPXML bounds https://openstudio-hpxml.readthedocs.io/en/latest/workflow_inputs.html#heat-pump
-          if new_uef <= 1.0
-            new_uef = 1.01
-          elsif new_uef > 5.0
-            new_uef = 5.0
-          end
+          new_uef = [[water_heating_system.uniform_energy_factor * multiplier, 1.01].max, 5.0].min
         else
-          new_uef = [water_heating_system.uniform_energy_factor * multiplier, 0.999].min
+          new_uef = [water_heating_system.uniform_energy_factor * multiplier, 0.99].min
         end
         if new_uef != water_heating_system.uniform_energy_factor
           water_heating_system.recovery_efficiency = nil

--- a/src/measures/ModifyXML/measure.xml
+++ b/src/measures/ModifyXML/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>modify_xml</name>
   <uid>afd74b96-8b2c-4ebd-83be-0d3fdc35bf9a</uid>
-  <version_id>5d696461-ebec-42e2-8039-c716c963baf8</version_id>
-  <version_modified>2025-07-24T16:09:32Z</version_modified>
+  <version_id>4f30eb9c-a8ac-44d9-a84e-35c2554b5c34</version_id>
+  <version_modified>2025-07-30T22:48:36Z</version_modified>
   <xml_checksum>1B7C870F</xml_checksum>
   <class_name>ModifyXML</class_name>
   <display_name>ModifyXML</display_name>
@@ -233,13 +233,13 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>60E3EAA3</checksum>
+      <checksum>DDCC2EB1</checksum>
     </file>
     <file>
       <filename>modify_xml_test.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>2AF5841A</checksum>
+      <checksum>B61631E7</checksum>
     </file>
   </files>
 </measure>

--- a/src/measures/ModifyXML/tests/modify_xml_test.rb
+++ b/src/measures/ModifyXML/tests/modify_xml_test.rb
@@ -402,27 +402,17 @@ class ModifyXMLTest < Minitest::Test
         new_water_heating_system = hpxml_bldg.water_heating_systems.find{ |dhw| dhw.id == water_heating_system.id }
         if water_heating_system.energy_factor
           if water_heating_system.water_heater_type == HPXML::WaterHeaterTypeHeatPump
-            expected_efficiency = (water_heating_system.energy_factor * ( 1 + args_hash['water_heater_efficiency_pct_change'])).round(2)
-            if expected_efficiency <= 1.0
-              expected_efficiency = 1.01
-            elsif expected_efficiency > 5.0
-              expected_efficiency = 5.0
-            end
+            expected_efficiency = [[(water_heating_system.energy_factor * ( 1 + args_hash['water_heater_efficiency_pct_change'])).round(2), 1.01].max, 5.0].min
           else
-            expected_efficiency = [(water_heating_system.energy_factor * ( 1 + args_hash['water_heater_efficiency_pct_change'])).round(2), 0.999].min
+            expected_efficiency = [(water_heating_system.energy_factor * ( 1 + args_hash['water_heater_efficiency_pct_change'])).round(2), 0.99].min
           end
           assert_equal(expected_efficiency, new_water_heating_system.energy_factor)
         end
         if water_heating_system.uniform_energy_factor
           if water_heating_system.water_heater_type == HPXML::WaterHeaterTypeHeatPump
-            expected_efficiency = (water_heating_system.uniform_energy_factor * ( 1 + args_hash['water_heater_efficiency_pct_change'])).round(2)
-            if expected_efficiency <= 1.0
-              expected_efficiency = 1.01
-            elsif expected_efficiency > 5.0
-              expected_efficiency = 5.0
-            end
+            expected_efficiency = [[(water_heating_system.uniform_energy_factor * ( 1 + args_hash['water_heater_efficiency_pct_change'])).round(2), 1.01].max, 5.0].min
           else
-            expected_efficiency = [(water_heating_system.uniform_energy_factor * ( 1 + args_hash['water_heater_efficiency_pct_change'])).round(2), 0.999].min
+            expected_efficiency = [(water_heating_system.uniform_energy_factor * ( 1 + args_hash['water_heater_efficiency_pct_change'])).round(2), 0.99].min
           end
           assert_equal(expected_efficiency, new_water_heating_system.uniform_energy_factor)
         end


### PR DESCRIPTION
- Set `recovery_efficiency` to nil when adjusting DHW EF/UEF
- Limit EF/UEF to 1.0 if DHW is not a heat pump

Note, this is branched off @bpark1327's branch, not `main`.