### PR TITLE
Avoid deepcopy

### DIFF
--- a/src/openstudio_hpxml_calibration/calibrate.py
+++ b/src/openstudio_hpxml_calibration/calibrate.py
@@ -456,9 +456,9 @@ class Calibrate:
             num_days = (last_bill_date - first_bill_date + timedelta(days=1)).days
             for period_consumption in delivered_consumption.ConsumptionDetail:
                 measured_consumption += float(period_consumption.Consumption)
-            logger.debug(
-                f"Measured {fuel_type} consumption: {measured_consumption:,.2f} {fuel_unit_type}"
-            )
+            # logger.debug(
+            #     f"Measured {fuel_type} consumption: {measured_consumption:,.2f} {fuel_unit_type}"
+            # )
             if fuel_unit_type == "gal" and fuel_type == FuelType.FUEL_OIL.value:
                 fuel_unit_type = f"{fuel_unit_type}_fuel_oil"
             elif fuel_unit_type == "gal" and fuel_type == FuelType.PROPANE.value:


### PR DESCRIPTION
This should avoid the need to use deepcopy in the `compare_results` method.

~The other use of deepcopy is in the `simplified_annual_usage` method. I don't immediately see why that should be needed, I don't see where either of the objects is directly modified...~ Addressed by Nate.