### PR TITLE
Add concurrency to stop previous CI job

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,4 +43,3 @@ Ruby Measure tests can be run with `openstudio src/measures/ModifyXML/tests/modi
 ## License
 
 This project is available under a BSD-3-like license, which is a free, open-source, and permissive license. For more information, check out the [license file](https://github.com/NREL/OpenStudio-HPXML-Calibration/blob/main/LICENSE.md).
-


### PR DESCRIPTION
Stops existing CI job when new commits are pushed. We use this in the OS-HXPML, ResStock, etc. repos.